### PR TITLE
Improve fetchCSVData error handling

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -169,5 +169,8 @@ export const determineProfessionalLevel = (
  */
 export const fetchCSVData = async (url: string): Promise<string> => {
   const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch CSV data: ${response.status}`);
+  }
   return await response.text();
 };


### PR DESCRIPTION
## Summary
- add `response.ok` check in `fetchCSVData` to throw error on failed HTTP requests

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6849a274cdb48324bc5c093a969b37dd